### PR TITLE
Bytebuddy object superclass

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.artlibs</groupId>
     <artifactId>autotrace4j</artifactId>
-    <version>0.2.1</version>
+    <version>0.2.2</version>
     <packaging>jar</packaging>
 
     <url>https://github.com/artlibs/autotrace4j</url>

--- a/src/main/java/io/github/artlibs/autotrace4j/AutoTrace4j.java
+++ b/src/main/java/io/github/artlibs/autotrace4j/AutoTrace4j.java
@@ -8,7 +8,9 @@ import io.github.artlibs.autotrace4j.transformer.At4jTransformer;
 import io.github.artlibs.autotrace4j.transformer.TransformListener;
 import io.github.artlibs.autotrace4j.support.ClassUtils;
 import io.github.artlibs.autotrace4j.support.ModuleUtils;
+import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.dynamic.scaffold.MethodGraph;
 
 import java.io.IOException;
 import java.lang.instrument.Instrumentation;
@@ -109,7 +111,9 @@ public final class AutoTrace4j {
          * @return AgentBuilder 一个 ByteBuddy Agent Builder
          */
         private AgentBuilder newAgentBuilder() {
-            return new AgentBuilder.Default()
+            ByteBuddy byteBuddy = new ByteBuddy()
+                    .with(MethodGraph.Compiler.ForDeclaredMethods.INSTANCE);
+            return new AgentBuilder.Default(byteBuddy)
                     .ignore(nameStartsWith("jdk.jfr.")
                             .or(nameStartsWith("com.intellij.rt."))
                             .or(nameStartsWith(AutoTrace4j.class.getPackage().getName()))

--- a/src/main/java/io/github/artlibs/autotrace4j/AutoTrace4j.java
+++ b/src/main/java/io/github/artlibs/autotrace4j/AutoTrace4j.java
@@ -111,6 +111,7 @@ public final class AutoTrace4j {
          * @return AgentBuilder 一个 ByteBuddy Agent Builder
          */
         private AgentBuilder newAgentBuilder() {
+            // Work around MethodGraph resolution failures on JDK classes (see #19).
             ByteBuddy byteBuddy = new ByteBuddy()
                     .with(MethodGraph.Compiler.ForDeclaredMethods.INSTANCE);
             return new AgentBuilder.Default(byteBuddy)


### PR DESCRIPTION
Configure ByteBuddy to use `MethodGraph.Compiler.ForDeclaredMethods` to fix `IllegalStateException` when resolving super classes during instrumentation of JDK classes (e.g., under JRebel).

---
<a href="https://cursor.com/background-agent?bcId=bc-7d4aac75-37f3-404a-838b-828a25a860b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7d4aac75-37f3-404a-838b-828a25a860b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Configures ByteBuddy to use declared-method graph compilation for more robust instrumentation and bumps the artifact version.
> 
> - Build `AgentBuilder` with a `ByteBuddy` instance configured via `MethodGraph.Compiler.ForDeclaredMethods` in `AutoTrace4j`, improving superclass resolution during JDK class instrumentation
> - Update `pom.xml` version from `0.2.1` to `0.2.2`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b420aa0796bf5f1bfe0d5c2f20c956cae6cfb27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->