### PR TITLE
Avoid method graph resolution for ByteBuddy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.artlibs</groupId>
     <artifactId>autotrace4j</artifactId>
-    <version>0.2.1</version>
+    <version>0.2.2</version>
     <packaging>jar</packaging>
 
     <url>https://github.com/artlibs/autotrace4j</url>

--- a/src/main/java/io/github/artlibs/autotrace4j/AutoTrace4j.java
+++ b/src/main/java/io/github/artlibs/autotrace4j/AutoTrace4j.java
@@ -8,7 +8,9 @@ import io.github.artlibs.autotrace4j.transformer.At4jTransformer;
 import io.github.artlibs.autotrace4j.transformer.TransformListener;
 import io.github.artlibs.autotrace4j.support.ClassUtils;
 import io.github.artlibs.autotrace4j.support.ModuleUtils;
+import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.dynamic.scaffold.MethodGraph;
 
 import java.io.IOException;
 import java.lang.instrument.Instrumentation;
@@ -109,7 +111,10 @@ public final class AutoTrace4j {
          * @return AgentBuilder 一个 ByteBuddy Agent Builder
          */
         private AgentBuilder newAgentBuilder() {
-            return new AgentBuilder.Default()
+            // Work around MethodGraph resolution failures on JDK classes (see #21).
+            ByteBuddy byteBuddy = new ByteBuddy()
+                    .with(MethodGraph.Compiler.ForDeclaredMethods.INSTANCE);
+            return new AgentBuilder.Default(byteBuddy)
                     .ignore(nameStartsWith("jdk.jfr.")
                             .or(nameStartsWith("com.intellij.rt."))
                             .or(nameStartsWith(AutoTrace4j.class.getPackage().getName()))


### PR DESCRIPTION
Bump version to 0.2.2

Refs #21: document ByteBuddy workaround

Avoid method graph resolution for ByteBuddy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Configures ByteBuddy to avoid method graph resolution issues and releases a new patch version.
> 
> - In `AutoTrace4j.newAgentBuilder()`, instantiate a custom `ByteBuddy` with `MethodGraph.Compiler.ForDeclaredMethods` and pass it to `AgentBuilder.Default(...)` to work around resolution failures on JDK classes
> - Add necessary imports and keep existing ignore/retransformation/injection settings unchanged
> - Bump artifact version in `pom.xml` from `0.2.1` to `0.2.2`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3b01c4aeaf4d80532cf0c5f493fb4bde12f5579. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->