### PR TITLE
Feat/bytebuddy object superclass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Run Tests
         run: make test
       - name: Upload Agent Jar Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Package
           path: target

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.artlibs</groupId>
     <artifactId>autotrace4j</artifactId>
-    <version>0.2.1</version>
+    <version>0.2.2</version>
     <packaging>jar</packaging>
 
     <url>https://github.com/artlibs/autotrace4j</url>

--- a/src/main/java/io/github/artlibs/autotrace4j/AutoTrace4j.java
+++ b/src/main/java/io/github/artlibs/autotrace4j/AutoTrace4j.java
@@ -8,7 +8,9 @@ import io.github.artlibs.autotrace4j.transformer.At4jTransformer;
 import io.github.artlibs.autotrace4j.transformer.TransformListener;
 import io.github.artlibs.autotrace4j.support.ClassUtils;
 import io.github.artlibs.autotrace4j.support.ModuleUtils;
+import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.dynamic.scaffold.MethodGraph;
 
 import java.io.IOException;
 import java.lang.instrument.Instrumentation;
@@ -109,7 +111,10 @@ public final class AutoTrace4j {
          * @return AgentBuilder 一个 ByteBuddy Agent Builder
          */
         private AgentBuilder newAgentBuilder() {
-            return new AgentBuilder.Default()
+            // Work around MethodGraph resolution failures on JDK classes (see #21).
+            ByteBuddy byteBuddy = new ByteBuddy()
+                    .with(MethodGraph.Compiler.ForDeclaredMethods.INSTANCE);
+            return new AgentBuilder.Default(byteBuddy)
                     .ignore(nameStartsWith("jdk.jfr.")
                             .or(nameStartsWith("com.intellij.rt."))
                             .or(nameStartsWith(AutoTrace4j.class.getPackage().getName()))


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Core change**
> 
> - Initialize `AgentBuilder` with a custom `ByteBuddy` using `MethodGraph.Compiler.ForDeclaredMethods` in `AutoTrace4j.newAgentBuilder()` to avoid method graph resolution failures on JDK classes.
> 
> **Release/CI**
> 
> - Bump project version to `0.2.2` in `pom.xml`.
> - Update GitHub Actions to `actions/upload-artifact@v4` in `release.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51dc4b743a79cc5aa836eff3f52a3727d1a26025. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->